### PR TITLE
Dropping root privileges in AI_INFN jupyter containers and adding GHA workflow

### DIFF
--- a/.github/workflows/publish-jlab-aiinfn.yaml
+++ b/.github/workflows/publish-jlab-aiinfn.yaml
@@ -17,16 +17,13 @@ jobs:
         run: echo "${{ secrets.GHCR_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
       - name: Pull base image
-        env:
-          DOCKER_CLIENT_TIMEOUT: 300
-          COMPOSE_HTTP_TIMEOUT: 302
-
-        run: docker pull harbor.cloud.infn.it/datacloud-templates/jlab-base:2.0.0
+        run: |
+          docker build -t harbor.cloud.infn.it/datacloud-templates/jlab-base:2.0.0 docker/singlenode/jlab-base
 
       - name: Build Docker image
         run: |
           IMAGE_NAME=ghcr.io/${{ github.repository }}/jlab-ai-infn:head
-          cd docker/ai_infn/jlab
+          cd 
           docker build -t $IMAGE_NAME .
 
       - name: Push Docker image

--- a/.github/workflows/publish-jlab-aiinfn.yaml
+++ b/.github/workflows/publish-jlab-aiinfn.yaml
@@ -3,7 +3,7 @@ name: Build and Push Docker Image
 on:
   push:
     branches:
-      - main
+      - master
 
 jobs:
   build-and-push:

--- a/.github/workflows/publish-jlab-aiinfn.yaml
+++ b/.github/workflows/publish-jlab-aiinfn.yaml
@@ -1,0 +1,29 @@
+name: Build and Push Docker Image
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Log in to GHCR
+        run: echo "${{ secrets.GHCR_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Build Docker image
+        run: |
+          IMAGE_NAME=ghcr.io/${{ github.repository }}/jlab-ai-infn:head
+          cd docker/ai_infn/jlab
+          docker build -t $IMAGE_NAME .
+
+      - name: Push Docker image
+        run: |
+          IMAGE_NAME=ghcr.io/${{ github.repository }}/jlab-ai-infn:head
+          docker push $IMAGE_NAME
+

--- a/.github/workflows/publish-jlab-aiinfn.yaml
+++ b/.github/workflows/publish-jlab-aiinfn.yaml
@@ -16,6 +16,9 @@ jobs:
       - name: Log in to GHCR
         run: echo "${{ secrets.GHCR_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
+      - name: Pull base image
+        run: docker pull harbor.cloud.infn.it/datacloud-templates/jlab-base:2.0.0
+
       - name: Build Docker image
         run: |
           IMAGE_NAME=ghcr.io/${{ github.repository }}/jlab-ai-infn:head

--- a/.github/workflows/publish-jlab-aiinfn.yaml
+++ b/.github/workflows/publish-jlab-aiinfn.yaml
@@ -16,17 +16,16 @@ jobs:
       - name: Log in to GHCR
         run: echo "${{ secrets.GHCR_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
-      - name: Pull base image
+      - name: Build base Docker image
         run: |
           docker build -t harbor.cloud.infn.it/datacloud-templates/jlab-base:2.0.0 docker/singlenode/jlab-base
 
-      - name: Build Docker image
+      - name: Build custom Docker image
         run: |
           IMAGE_NAME=ghcr.io/${{ github.repository }}/jlab-ai-infn:head
-          cd 
-          docker build -t $IMAGE_NAME .
+          docker build -t $IMAGE_NAME docker/ai_infn/jlab/
 
-      - name: Push Docker image
+      - name: Push Docker image to GHCR
         run: |
           IMAGE_NAME=ghcr.io/${{ github.repository }}/jlab-ai-infn:head
           docker push $IMAGE_NAME

--- a/.github/workflows/publish-jlab-aiinfn.yaml
+++ b/.github/workflows/publish-jlab-aiinfn.yaml
@@ -17,6 +17,10 @@ jobs:
         run: echo "${{ secrets.GHCR_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
       - name: Pull base image
+        env:
+          DOCKER_CLIENT_TIMEOUT: 300
+          COMPOSE_HTTP_TIMEOUT: 302
+
         run: docker pull harbor.cloud.infn.it/datacloud-templates/jlab-base:2.0.0
 
       - name: Build Docker image

--- a/docker/ai_infn/jlab/Dockerfile
+++ b/docker/ai_infn/jlab/Dockerfile
@@ -58,8 +58,3 @@ RUN sed -i 's/:\/root:/:\/home\/private:/g' /etc/passwd
 # Import configuration of sshd
 COPY ./sshd.conf /etc/ssh/sshd_config.d/aiinfn.conf 
 
-# Clean home of default jupyter user
-RUN rm -rf /home/jovyan
-
-WORKDIR /home
-ENTRYPOINT []

--- a/docker/ai_infn/jlab/Dockerfile
+++ b/docker/ai_infn/jlab/Dockerfile
@@ -62,4 +62,7 @@ COPY ./sshd.conf /etc/ssh/sshd_config.d/aiinfn.conf
 COPY ./create_user_groups.py /usr/local/bin/before-notebook.d/05_create_user_groups.py
 RUN chmod a+rx /usr/local/bin/before-notebook.d/05_create_user_groups.py
 
+RUN echo "rm -rf /home/jovyan" > /usr/local/bin/before-notebook.d/101_cleanup_jovyan.py && \
+    chmod a+rx /usr/local/bin/before-notebook.d/99_cleanup_jovyan.py 
+
 WORKDIR /home

--- a/docker/ai_infn/jlab/Dockerfile
+++ b/docker/ai_infn/jlab/Dockerfile
@@ -58,3 +58,4 @@ RUN sed -i 's/:\/root:/:\/home\/private:/g' /etc/passwd
 # Import configuration of sshd
 COPY ./sshd.conf /etc/ssh/sshd_config.d/aiinfn.conf 
 
+WORKDIR /home

--- a/docker/ai_infn/jlab/Dockerfile
+++ b/docker/ai_infn/jlab/Dockerfile
@@ -58,4 +58,8 @@ RUN sed -i 's/:\/root:/:\/home\/private:/g' /etc/passwd
 # Import configuration of sshd
 COPY ./sshd.conf /etc/ssh/sshd_config.d/aiinfn.conf 
 
+# Enable defining secondary groups through env var $NB_GROUPS
+COPY ./create_user_groups.py /usr/local/bin/before-notebook.d/05_create_user_groups.py
+RUN chmod a+rx /usr/local/bin/before-notebook.d/05_create_user_groups.py
+
 WORKDIR /home

--- a/docker/ai_infn/jlab/Dockerfile
+++ b/docker/ai_infn/jlab/Dockerfile
@@ -62,7 +62,7 @@ COPY ./sshd.conf /etc/ssh/sshd_config.d/aiinfn.conf
 COPY ./create_user_groups.py /usr/local/bin/before-notebook.d/05_create_user_groups.py
 RUN chmod a+rx /usr/local/bin/before-notebook.d/05_create_user_groups.py
 
-RUN echo "rm -rf /home/jovyan" > /usr/local/bin/before-notebook.d/101_cleanup_jovyan.py && \
-    chmod a+rx /usr/local/bin/before-notebook.d/99_cleanup_jovyan.py 
+RUN echo "rm -rf /home/jovyan" >  /usr/local/bin/before-notebook.d/99_cleanup_jovyan.sh 
+RUN chmod a+rx                    /usr/local/bin/before-notebook.d/99_cleanup_jovyan.sh 
 
 WORKDIR /home

--- a/docker/ai_infn/jlab/create_user_groups.py
+++ b/docker/ai_infn/jlab/create_user_groups.py
@@ -14,12 +14,20 @@ For example,
 
 import os
 import subprocess
+import traceback
 
+
+print (f"Processing NB_GROUPS={os.environ.get('NB_GROUPS', '')")
 groups = os.environ.get("NB_GROUPS", "").split(", ")
 username = os.environ.get("NB_USER", os.environ.get("JUPYTERHUB_USER", "jovyan"))
 
 for group in groups:
-    gid, groupname = group.split(":")
-    subprocess.run(["addgroup", "--gid", gid, groupname])
-    subprocess.run(["adduser", username, groupname])
+    try:
+        gid, groupname = group.split(":")
+        subprocess.run(["addgroup", "--gid", gid, groupname])
+        subprocess.run(["adduser", username, groupname])
+    except:
+        traceback.print_exc()
+        print ("Failed processing group: ", group)
+
 

--- a/docker/ai_infn/jlab/create_user_groups.py
+++ b/docker/ai_infn/jlab/create_user_groups.py
@@ -17,7 +17,7 @@ import subprocess
 import traceback
 
 
-print (f"Processing NB_GROUPS={os.environ.get('NB_GROUPS', '')")
+print (f"Processing NB_GROUPS={os.environ.get('NB_GROUPS', '')}")
 groups = os.environ.get("NB_GROUPS", "").split(", ")
 username = os.environ.get("NB_USER", os.environ.get("JUPYTERHUB_USER", "jovyan"))
 

--- a/docker/ai_infn/jlab/create_user_groups.py
+++ b/docker/ai_infn/jlab/create_user_groups.py
@@ -1,0 +1,25 @@
+#!/bin/env python3
+"""
+Simple script creating groups for the NB_USER based on NB_GROUPS env var.
+The script is intended for Jupyter docker images inherinting from docker-stacks-foundation 
+and should be installed in /usr/local/bin/before-notebook.d/
+
+The format of the NB_GROUPS env var is:
+  NB_GROUPS=gid:group[,gid2:group2[, ...]]
+
+For example,
+  NB_GROUPS=4001:lhcb,4002:cms,4003:atlas
+
+"""
+
+import os
+import subprocess
+
+groups = os.environ.get("NB_GROUPS", "").split(", ")
+username = os.environ.get("NB_USER", os.environ.get("JUPYTERHUB_USER", "jovyan"))
+
+for group in groups:
+    gid, groupname = group.split(":")
+    subprocess.run(["addgroup", "--gid", gid, groupname])
+    subprocess.run(["adduser", username, groupname])
+


### PR DESCRIPTION
The most critical aspects of the AI_INFN platform, preventing it's adoption in larger contexts are:
 * the jupyterlab container running as privileged 
 * the shared file system using soft isolation, but without any UID:GID control 

While addressing these points we have updated the image to:
 * run the standard entrypoint of docker `start.sh` instead of running a custom script. `start.sh` takes care of creating the unprivileged user based on environment variables set by the spawner.
 * assign the user to secondary groups based on the new NB_GROUPS environment variable. This is needed to enable per-group permission management in the shared file system.
 * remove the /home/jovyan directory as part of the start up process (otherwise it gets re-created by `start.sh`)

To ease testing these modifications, we automatically build and push the image to GHCR at each push, adding a `build-and-push` workflow to GitHub actions.

# Important! Broken backward-compatibility!!!
**This pull request breaks compatibility. The platform running today on hub.ai.cloud.infn.it, running the user's container as privileged, will fail to spawn this image.**
